### PR TITLE
cpu: add basic support for some 65C02 opcodes

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -643,6 +643,7 @@ func (c *Cpu) PHA(in Instruction) {
 func (c *Cpu) PLA(in Instruction) {
 	c.SP++
 	c.AC = c.Bus.Read(0x0100 + uint16(c.SP))
+	c.updateStatus(c.AC)
 }
 
 // PHX: Push X onto stack.
@@ -655,6 +656,7 @@ func (c *Cpu) PHX(in Instruction) {
 func (c *Cpu) PLX(in Instruction) {
 	c.SP++
 	c.X = c.Bus.Read(0x0100 + uint16(c.SP))
+	c.updateStatus(c.X)
 }
 
 // PHY: Push Y onto stack.
@@ -667,6 +669,7 @@ func (c *Cpu) PHY(in Instruction) {
 func (c *Cpu) PLY(in Instruction) {
 	c.SP++
 	c.Y = c.Bus.Read(0x0100 + uint16(c.SP))
+	c.updateStatus(c.Y)
 }
 
 // ROL: Rotate memory or accumulator left one bit.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -481,7 +481,7 @@ func (c *Cpu) CLD(in Instruction) {
 
 // CLI: Clear interrupt-disable flag.
 func (c *Cpu) CLI(in Instruction) {
-	c.setStatus(sInterrupt, true)
+	c.setStatus(sInterrupt, false)
 }
 
 // CMP: Compare accumulator with memory.
@@ -748,7 +748,7 @@ func (c *Cpu) SED(in Instruction) {
 
 // SEI: Set interrupt-disable flag.
 func (c *Cpu) SEI(in Instruction) {
-	c.setStatus(sInterrupt, false)
+	c.setStatus(sInterrupt, true)
 }
 
 // STA: Store accumulator to memory.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -278,6 +278,10 @@ func (c *Cpu) execute(in Instruction) {
 		c.NOP(in)
 	case ora:
 		c.ORA(in)
+	case php:
+		c.PHP(in)
+	case plp:
+		c.PLP(in)
 	case pha:
 		c.PHA(in)
 	case pla:
@@ -597,6 +601,18 @@ func (c *Cpu) NOP(in Instruction) {
 func (c *Cpu) ORA(in Instruction) {
 	c.AC |= c.resolveOperand(in)
 	c.updateStatus(c.AC)
+}
+
+// PHP: Push status onto stack.
+func (c *Cpu) PHP(in Instruction) {
+	c.Bus.Write(0x0100+uint16(c.SP), c.SR)
+	c.SP--
+}
+
+// PLP: Pull status from stack.
+func (c *Cpu) PLP(in Instruction) {
+	c.SP++
+	c.SR = c.Bus.Read(0x0100 + uint16(c.SP))
 }
 
 // PHA: Push accumulator onto stack.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -163,6 +163,10 @@ func (c *Cpu) memoryAddress(in Instruction) uint16 {
 	case indirect:
 		return c.Bus.Read16(uint16(in.Op16))
 
+	// This is like indirectX but uses a full 16-bit absolute address.
+	case indirectX16:
+		return c.Bus.Read16(in.Op16 + uint16(c.X))
+
 	default:
 		panic(fmt.Sprintf("unhandled addressing mode: %v",
 			addressingNames[in.addressing]))

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -298,6 +298,8 @@ func (c *Cpu) execute(in Instruction) {
 		c.RTS(in)
 	case sbc:
 		c.SBC(in)
+	case sed:
+		c.SED(in)
 	case sec:
 		c.SEC(in)
 	case sei:
@@ -737,6 +739,11 @@ func (c *Cpu) SBC(in Instruction) {
 // SEC: Set carry flag.
 func (c *Cpu) SEC(in Instruction) {
 	c.setStatus(sCarry, true)
+}
+
+// SED: Set decimal mode flag.
+func (c *Cpu) SED(in Instruction) {
+	c.setStatus(sDecimal, true)
 }
 
 // SEI: Set interrupt-disable flag.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -234,6 +234,10 @@ func (c *Cpu) execute(in Instruction) {
 		c.BNE(in)
 	case bpl:
 		c.BPL(in)
+	case bvs:
+		c.BVS(in)
+	case bvc:
+		c.BVC(in)
 	case brk:
 		c.BRK(in)
 	case clc:
@@ -382,6 +386,20 @@ func (c *Cpu) BCC(in Instruction) {
 // BCS: Branch if carry set.
 func (c *Cpu) BCS(in Instruction) {
 	if c.getStatus(sCarry) {
+		c.branch(in)
+	}
+}
+
+// BVC: Branch if overflow clear.
+func (c *Cpu) BVC(in Instruction) {
+	if !c.getStatus(sOverflow) {
+		c.branch(in)
+	}
+}
+
+// BVS: Branch if overflow set.
+func (c *Cpu) BVS(in Instruction) {
+	if c.getStatus(sOverflow) {
 		c.branch(in)
 	}
 }

--- a/cpu/op_type.go
+++ b/cpu/op_type.go
@@ -334,7 +334,7 @@ var optypes = map[uint8]OpType{
 	0x48: OpType{0x48, pha, implied, 1, 3},
 	0x08: OpType{0x08, php, implied, 1, 3},
 	0x68: OpType{0x68, pla, implied, 1, 4},
-	0x28: OpType{0x28, php, implied, 1, 4},
+	0x28: OpType{0x28, plp, implied, 1, 4},
 	0x2A: OpType{0x2A, rol, accumulator, 1, 2},
 	0x26: OpType{0x26, rol, zeropage, 2, 5},
 	0x36: OpType{0x36, rol, zeropageX, 2, 6},

--- a/cpu/op_type.go
+++ b/cpu/op_type.go
@@ -21,6 +21,7 @@ const (
 
 	// 65C02 only
 	zpindirect
+	indirectX16
 )
 
 var addressingNames = [...]string{
@@ -39,6 +40,7 @@ var addressingNames = [...]string{
 	"zeropageX",
 	"zeropageY",
 	"(zeropage)",
+	"(absolute,X)",
 }
 
 // adc..tya represent the 6502 instruction set mnemonics. Each mnemonic maps to
@@ -394,7 +396,7 @@ var optypes = map[uint8]OpType{
 	0x3C: OpType{0x3C, bit, absoluteX, 3, 4},
 	0x3A: OpType{0x3A, dec, implied, 1, 2},
 	0x1A: OpType{0x1A, inc, implied, 1, 2},
-	0x7C: OpType{0x7C, jmp, absoluteX, 3, 6},
+	0x7C: OpType{0x7C, jmp, indirectX16, 3, 6},
 
 	// New instructions
 	0x80: OpType{0x80, bra, relative, 2, 3},

--- a/cpu/op_type.go
+++ b/cpu/op_type.go
@@ -18,6 +18,9 @@ const (
 	zeropage
 	zeropageX
 	zeropageY
+
+	// 65C02 only
+	zpindirect
 )
 
 var addressingNames = [...]string{
@@ -35,6 +38,7 @@ var addressingNames = [...]string{
 	"zeropage",
 	"zeropageX",
 	"zeropageY",
+	"(zeropage)",
 }
 
 // adc..tya represent the 6502 instruction set mnemonics. Each mnemonic maps to
@@ -97,6 +101,17 @@ const (
 	txa
 	txs
 	tya
+
+	// 65{S}C02-only
+	bra
+	phx
+	phy
+	plx
+	ply
+	stz
+	trb
+	tsb
+
 	_end
 )
 
@@ -158,6 +173,17 @@ var instructionNames = [...]string{
 	"TXA",
 	"TXS",
 	"TYA",
+
+	// 65{S}C02-only
+	"BRA",
+	"PHX",
+	"PHY",
+	"PLX",
+	"PLY",
+	"STZ",
+	"TRB",
+	"TSB",
+
 	"_END",
 }
 
@@ -351,5 +377,39 @@ var optypes = map[uint8]OpType{
 	0x8A: OpType{0x8A, txa, implied, 1, 2},
 	0x9A: OpType{0x9A, txs, implied, 1, 2},
 	0x98: OpType{0x98, tya, implied, 1, 2},
+
+	// 65C02 only
+
+	// Additional addressing modes
+	0x12: OpType{0x12, ora, zpindirect, 2, 5},
+	0x32: OpType{0x32, and, zpindirect, 2, 5},
+	0x52: OpType{0x52, eor, zpindirect, 2, 5},
+	0x72: OpType{0x72, adc, zpindirect, 2, 5},
+	0x92: OpType{0x92, sta, zpindirect, 2, 5},
+	0xB2: OpType{0xB2, lda, zpindirect, 2, 5},
+	0xD2: OpType{0xD2, cmp, zpindirect, 2, 5},
+	0xF2: OpType{0xF2, sbc, zpindirect, 2, 5},
+	0x89: OpType{0x89, bit, immediate, 2, 2},
+	0x34: OpType{0x34, bit, zeropageX, 2, 4},
+	0x3C: OpType{0x3C, bit, absoluteX, 3, 4},
+	0x3A: OpType{0x3A, dec, implied, 1, 2},
+	0x1A: OpType{0x1A, inc, implied, 1, 2},
+	0x7C: OpType{0x7C, jmp, absoluteX, 3, 6},
+
+	// New instructions
+	0x80: OpType{0x80, bra, relative, 2, 3},
+	0xDA: OpType{0xDA, phx, implied, 1, 3},
+	0x5A: OpType{0x5A, phy, implied, 1, 3},
+	0xFA: OpType{0xFA, plx, implied, 1, 4},
+	0x7A: OpType{0x7A, ply, implied, 1, 4},
+	0x64: OpType{0x64, stz, zeropage, 2, 3},
+	0x74: OpType{0x74, stz, zeropageX, 2, 4},
+	0x9C: OpType{0x9C, stz, absolute, 3, 4},
+	0x9E: OpType{0x9E, stz, absoluteX, 3, 5},
+	0x14: OpType{0x14, trb, zeropage, 2, 5},
+	0x1C: OpType{0x1C, trb, absolute, 3, 6},
+	0x04: OpType{0x04, tsb, zeropage, 2, 5},
+	0x0C: OpType{0x0C, tsb, absolute, 3, 5},
+
 	0xFF: OpType{0xFF, _end, implied, 1, 1},
 }


### PR DESCRIPTION
This is very much a RFC rather than something which is finished and proposed for
merging. I've got my own 6502 homebrew project at https://github.com/rjw57/buri
and I make use of the 65C02 instructions such as PHX, PHY, etc.

This commit adds just enough support to boot the 65C02 ROM image I have. This is
a work-in-progress change and is not complete 65C02 support by any means.

My question is: is this worth pursuing further? Would you be interested in 65C02
support? If so, would you want some form of configuration allowing 65C02-support
to be switched on/off?
